### PR TITLE
Add Error Tracking Subsystem

### DIFF
--- a/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
@@ -1,0 +1,86 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMaxLowLevel.MotorType;
+import edu.wpi.first.networktables.*;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import java.util.ArrayList;
+
+public class ErrorTrackingSubsystem extends SubsystemBase {
+
+  ArrayList<CANSparkMax> motors = new ArrayList<>();
+  ArrayList<StringPublisher> motorPublishers = new ArrayList<>();
+  ArrayList<GenericEntry> motorEntries = new ArrayList<>();
+  int currentMotor = 0;
+  NetworkTable errorPublish;
+  ShuffleboardTab errorsTab;
+
+  private static ErrorTrackingSubsystem instance;
+    public static ErrorTrackingSubsystem getInstance(){
+        if(instance == null){
+            instance = new ErrorTrackingSubsystem();
+        }
+        return instance;
+    }
+  /** Creates a new ErrorTrackingSubsystem. */
+  public ErrorTrackingSubsystem() {
+    errorPublish = NetworkTableInstance.getDefault().getTable("CANSparkMax/Errors");
+    errorsTab = Shuffleboard.getTab("CANSparkMax Errors");
+    // Test code to register 25 can spark maxes
+    for (int i = 0; i < 25; i++) {
+      register(new CANSparkMax(i, MotorType.kBrushless));
+    }
+  }
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+    if (!motors.isEmpty()) {
+      short faults = motors.get(currentMotor).getStickyFaults();
+      motors.get(currentMotor).clearFaults();
+      StringPublisher publisher = motorPublishers.get(currentMotor);
+      String faultWords = faultWordToString(faults);
+      publisher.set(faultWords);
+      GenericEntry motorEntry = motorEntries.get(currentMotor);
+      motorEntry.setBoolean(faultWords.isEmpty());
+      if (currentMotor < motors.size() - 1 ) {
+        currentMotor++;
+      } else {
+        currentMotor = 0;
+      }
+    }
+  }
+
+  // function to register can spark maxes
+  public void register(CANSparkMax motor) {
+    motorEntries.add(errorsTab
+            .add(Integer.toString(motor.getDeviceId()), false)
+            .withPosition((3 * (motors.size() % 3)), motors.size() / 3)
+            // motor 1: (0, 0), 2: (3, 0), 3: (6, 0), 4: (9, 0), 5: (0, 1), 6: (3, 1), etc
+            .withSize(3, 1).getEntry());
+    motors.add(motor);
+    motorPublishers.add(errorPublish.getStringTopic(Integer.toString(motor.getDeviceId())).publish());
+  }
+
+  public static String faultWordToString(short faults) {
+    if (faults == 0) {
+      return "";
+    }
+
+    StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < 12; i++) {
+      if (((1 << i) & (int) faults) != 0) {
+        builder.append(CANSparkMax.FaultID.fromId(i).toString());
+        builder.append(" ");
+      }
+    }
+    return builder.toString();
+  }
+
+}

--- a/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
@@ -32,7 +32,7 @@ public class ErrorTrackingSubsystem extends SubsystemBase {
     /** Creates a new ErrorTrackingSubsystem. */
     public ErrorTrackingSubsystem() {
         errorPublish = NetworkTableInstance.getDefault().getTable("CANSparkMax/Errors"); // Errors will be sent to NetworkTables
-        errorsTab = Shuffleboard.getTab("CANSparkMax Errors"); // Errors will also be displayed on Shuffleboard
+        errorsTab = Shuffleboard.getTab("CANSparkMax Status"); // Errors will also be displayed on Shuffleboard
     }
     @Override
     public void periodic() {
@@ -60,9 +60,8 @@ public class ErrorTrackingSubsystem extends SubsystemBase {
     public void register(CANSparkMax motor) {
         motorEntries.add(errorsTab
                 .add(Integer.toString(motor.getDeviceId()), false)
-                .withPosition((3 * (motors.size() % 3)), motors.size() / 3)
-                // motor 1: (0, 0), 2: (3, 0), 3: (6, 0), 4: (9, 0), 5: (0, 1), 6: (3, 1), etc
-                .withSize(3, 1).getEntry());
+                .withPosition(( (motors.size() % 9)), motors.size() / 9)
+                .withSize(1, 1).getEntry());
         motors.add(motor);
         motorPublishers.add(errorPublish.getStringTopic(Integer.toString(motor.getDeviceId())).publish());
     }
@@ -88,3 +87,11 @@ public class ErrorTrackingSubsystem extends SubsystemBase {
     }
 
 }
+
+// todo
+// would be good to log
+// they need to know different blobs of information
+// 1. something is broken
+// 2. which is failing and what errors
+// Directly log it in stringlogentry
+

--- a/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ErrorTrackingSubsystem.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkLowLevel.MotorType;
+import edu.wpi.first.networktables.*;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import java.util.ArrayList;
+
+public class ErrorTrackingSubsystem extends SubsystemBase {
+
+    ArrayList<CANSparkMax> motors = new ArrayList<>();
+    ArrayList<StringPublisher> motorPublishers = new ArrayList<>();
+    ArrayList<GenericEntry> motorEntries = new ArrayList<>();
+    int currentMotor = 0;
+    NetworkTable errorPublish;
+    ShuffleboardTab errorsTab;
+
+    private static ErrorTrackingSubsystem instance;
+    public static ErrorTrackingSubsystem getInstance(){
+        if(instance == null){
+            instance = new ErrorTrackingSubsystem();
+        }
+        return instance;
+    }
+    /** Creates a new ErrorTrackingSubsystem. */
+    public ErrorTrackingSubsystem() {
+        errorPublish = NetworkTableInstance.getDefault().getTable("CANSparkMax/Errors"); // Errors will be sent to NetworkTables
+        errorsTab = Shuffleboard.getTab("CANSparkMax Errors"); // Errors will also be displayed on Shuffleboard
+    }
+    @Override
+    public void periodic() {
+        // This method will be called once per scheduler run
+        if (!motors.isEmpty()) { // Ensure motor list is not empty!
+            short faults = motors.get(currentMotor).getStickyFaults();
+            motors.get(currentMotor).clearFaults(); // we need to make sure to clear the bus, so it doesn't just add up
+            StringPublisher publisher = motorPublishers.get(currentMotor);
+            String faultWords = faultWordToString(faults); // the faults are marked as IDs and must be converted to strings
+            publisher.set(faultWords); // send to networktables
+            GenericEntry motorEntry = motorEntries.get(currentMotor); // Gets entry from shuffleboard
+            motorEntry.setBoolean(faultWords.isEmpty());
+            if (currentMotor < motors.size() - 1 ) {
+                currentMotor++; // Next, we will check the next motor, and we will keep incrementing it to not crowd the bus.
+            } else {
+                currentMotor = 0;
+            }
+        }
+    }
+
+    /**
+     * Function to register a new CANSparkMax to track errors from.
+     * @param motor A CANSparkMax object (the motor).
+     */
+    public void register(CANSparkMax motor) {
+        motorEntries.add(errorsTab
+                .add(Integer.toString(motor.getDeviceId()), false)
+                .withPosition((3 * (motors.size() % 3)), motors.size() / 3)
+                // motor 1: (0, 0), 2: (3, 0), 3: (6, 0), 4: (9, 0), 5: (0, 1), 6: (3, 1), etc
+                .withSize(3, 1).getEntry());
+        motors.add(motor);
+        motorPublishers.add(errorPublish.getStringTopic(Integer.toString(motor.getDeviceId())).publish());
+    }
+
+    /**
+     * Function to convert a "fault word" to a string.
+     * @param faults A short containing the faults.
+     * @return A string containing the faults as a string.
+     */
+    public static String faultWordToString(short faults) {
+        if (faults == 0) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 12; i++) {
+            if (((1 << i) & (int) faults) != 0) {
+                builder.append(CANSparkMax.FaultID.fromId(i).toString());
+                builder.append(" ");
+            }
+        }
+        return builder.toString();
+    }
+
+}


### PR DESCRIPTION
## Describe your changes

- [ ] Bug fix
- [x] New feature

Explain what you did:
> Added a new ErrorTrackingSubsystem. A user can register any CANSparkMax which will be checked one at a time every cycle. The errors will then be sent as a string to NetworkTables and a Shuffleboard tab. 

## Issue ticket (add number)
> https://github.com/FRC2706/2024-2706-Robot-Code/issues/15

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have tested thoroughly.
- [x] I have written documentation and explained about my changes to the best of my ability.
