### PR TITLE
Fix: Error in calculating if the swerve encoders are synced

### DIFF
--- a/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
@@ -6,6 +6,7 @@
 package frc.robot.robotcontainers;
 
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -150,7 +151,7 @@ public class NewRobotContainer extends RobotContainer {
     operator.a().onTrue(new SetArm(()->ArmSetPoints.INTAKE.angleDeg)); // Pickup
     operator.x().onTrue(new SetArm(()->ArmSetPoints.SPEAKER_KICKBOT_SHOT.angleDeg));
     // Climber
-    operator.leftTrigger(0.25).whileTrue(new ClimberRPM(()->  operator.getLeftTriggerAxis()));
+    operator.leftTrigger(0.35).whileTrue(new ClimberRPM(()-> MathUtil.applyDeadband(operator.getLeftTriggerAxis(), 0.35) * 0.5));
 
     // Eject the note from the front with start
     operator.start()

--- a/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
@@ -170,7 +170,7 @@ public class NewRobotContainer extends RobotContainer {
           new MakeIntakeMotorSpin(8.0,0));
 
       //NOTE: right Trigger has been assigned to climber
-      // operator.rightTrigger(0.3).whileTrue(CombinedCommands.simpleShootNoteAmp());
+      operator.rightTrigger(0.3).whileTrue(CombinedCommands.simpleShootNoteAmp());
       // Shoot note with leftBumper
       operator.rightBumper().whileTrue(CombinedCommands.simpleShootNoteSpeaker(1));
 

--- a/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
@@ -148,18 +148,16 @@ public class NewRobotContainer extends RobotContainer {
     operator.y().onTrue(new SetArm(()->ArmSetPoints.AMP.angleDeg)); // Amp
     operator.b().onTrue(new SetArm(()->ArmSetPoints.IDLE.angleDeg)); // Idle
     operator.a().onTrue(new SetArm(()->ArmSetPoints.INTAKE.angleDeg)); // Pickup
-    //XBoxControllerUtil.leftPOV(operator).debounce(0.1).onTrue(new SetArm(()->ArmSetPoints.SPEAKER_KICKBOT_SHOT.angleDeg)); // Kickbot Shot
     operator.x().onTrue(new SetArm(()->ArmSetPoints.SPEAKER_KICKBOT_SHOT.angleDeg));
     // Climber
     operator.leftTrigger(0.25).whileTrue(new ClimberRPM(()->  operator.getLeftTriggerAxis()));
 
-    // Eject the note from the front with leftPOV
+    // Eject the note from the front with start
     operator.start()
       .whileTrue(Commands.run(() -> intake.setVoltage(-12), intake))
       .onFalse(Commands.runOnce(() -> intake.stop()));
   
     
-    operator.back().whileTrue(new Shooter_PID_Tuner(shooterTargetRPM));
     // Simple shooter and intake
     if (Config.disableStateBasedProgramming) {
       intake.setStateMachineOff();
@@ -172,7 +170,7 @@ public class NewRobotContainer extends RobotContainer {
           new MakeIntakeMotorSpin(8.0,0));
 
       //NOTE: right Trigger has been assigned to climber
-      operator.rightTrigger(0.3).whileTrue(CombinedCommands.simpleShootNoteAmp());
+      // operator.rightTrigger(0.3).whileTrue(CombinedCommands.simpleShootNoteAmp());
       // Shoot note with leftBumper
       operator.rightBumper().whileTrue(CombinedCommands.simpleShootNoteSpeaker(1));
 
@@ -215,7 +213,7 @@ public class NewRobotContainer extends RobotContainer {
     //   .whileFalse(Commands.runOnce(()->intake.setMode(IntakeModes.STOP_INTAKE)));   
     
     // testJoystick.start().whileTrue( new SetArm(armAngleDeg));
-    // testJoystick.back().whileTrue(new Shooter_PID_Tuner(shooterTargetRPM));
+    // testJoystick.back().whileTrue(new Shooter_PID_Tuner(shooterTargetRPM)); 
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -11,6 +11,7 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkPIDController;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
@@ -282,7 +283,9 @@ public class SwerveModule {
   }
 
   public boolean isModuleSynced(){
-    if (Math.abs(getAngle().getDegrees() - (getCanCoder().getDegrees() - angleOffset.getDegrees())) < Config.Swerve.synchTolerance) {
+    double angleError = getAngle().getDegrees() - (getCanCoder().getDegrees() - angleOffset.getDegrees());
+
+    if (Math.abs(MathUtil.inputModulus(angleError, -180, 180)) < Config.Swerve.synchTolerance) {
       return true;
     }
     else{

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -283,8 +283,10 @@ public class SwerveModule {
   }
 
   public boolean isModuleSynced(){
+    // Calculate the angle error between the NEO encoder and cancoder
     double angleError = getAngle().getDegrees() - (getCanCoder().getDegrees() - angleOffset.getDegrees());
 
+    // Wrap the angle to (-180, 180], get the absolute value, then check if the error is less than the tolerance
     if (Math.abs(MathUtil.inputModulus(angleError, -180, 180)) < Config.Swerve.synchTolerance) {
       return true;
     }


### PR DESCRIPTION
## Describe your changes

- [x] Fixed an issue with the method isModuleSynced in SwerveModule

Explain what you did:
> This method is supposed to check if 2 angles are within ~3 degrees of each other but it wasn't properly handling angles that wrap around 0 to 360 or angles that had different ranges. For example, the cancoder minus offset might be in the range of [40, 400) if the offset if -40 degrees. 
> Fix: After subtracting the angles to find the error, I forced the angleError to be in the range of -180 to 180.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] I have tested thoroughly.
- [x] I have written documentation and explained about my changes to the best of my ability.
