### PR TITLE
Protect the arm from the climber

### DIFF
--- a/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
@@ -11,7 +11,6 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.lib.lib2706.SelectByAllianceCommand;
 import frc.lib.lib2706.TunableNumber;
 import frc.lib.lib2706.XBoxControllerUtil;
 import frc.robot.Config;
@@ -32,9 +31,9 @@ import frc.robot.commands.Shooter_PID_Tuner;
 import frc.robot.commands.TeleopSwerve;
 import frc.robot.commands.auto.AutoRoutines;
 import frc.robot.commands.auto.AutoSelector;
+import frc.robot.subsystems.ArmSubsystem;
 import frc.robot.subsystems.IntakeStatesMachine.IntakeModes;
 import frc.robot.subsystems.IntakeSubsystem;
-import frc.robot.subsystems.PhotonSubsystem;
 import frc.robot.subsystems.ShooterStateMachine.ShooterModes;
 import frc.robot.subsystems.ShooterSubsystem;
 import frc.robot.subsystems.SwerveSubsystem;
@@ -151,7 +150,9 @@ public class NewRobotContainer extends RobotContainer {
     //XBoxControllerUtil.leftPOV(operator).debounce(0.1).onTrue(new SetArm(()->ArmSetPoints.SPEAKER_KICKBOT_SHOT.angleDeg)); // Kickbot Shot
     operator.x().onTrue(new SetArm(()->ArmSetPoints.SPEAKER_KICKBOT_SHOT.angleDeg));
     // Climber
-    operator.leftTrigger(0.25).whileTrue(new ClimberRPM(()->  operator.getLeftTriggerAxis()));
+    operator.leftTrigger(0.25)
+            .and(new Trigger(() -> ArmSubsystem.getInstance().getPosition() < Math.toRadians(55)))
+            .whileTrue(new ClimberRPM(()->  operator.getLeftTriggerAxis()));
 
     // Eject the note from the front with leftPOV
     operator.start()


### PR DESCRIPTION
## Describe your changes

- [x] The climber winch is not allowed to move when the arm is above a certain angle.

If the arm is in the amp scoring position and the climber is released, the climber will block the arm until the climber hooks are lowered enough. It might be possible for the climber to hook on to the intake and break it if the climber pulls it down.

The arm must be lowered to the pickup or speaker shot position before climbing.


![image](https://github.com/FRC2706/2024-2706-Robot-Code/assets/43829793/34f5a0af-1289-4ea5-b7c2-86f152701eae)
![image](https://github.com/FRC2706/2024-2706-Robot-Code/assets/43829793/0e67558d-3732-4238-b959-d92719829eda)
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] I have tested thoroughly. (Testing at everline tomorrow or closing PR)
- [x] I have written documentation and explained about my changes to the best of my ability.
