### PR TITLE
Implement manual encoder syncing but maintain automatic syncing for auto only

### DIFF
--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -221,7 +221,7 @@ public final class Config {
     public static final double driveGearRatio = (8.14 / 1.0);
     public static final double angleGearRatio = (12.8 / 1.0);
 
-    public static final double synchTolerance = 3;
+    public static final double synchTolerance = 1;
     
     public static final SwerveDriveKinematics swerveKinematics =
         new SwerveDriveKinematics(

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -36,9 +36,6 @@ public class Robot extends TimedRobot {
   private RobotContainer m_robotContainer;
   public static CTREConfigs ctreConfigs = new CTREConfigs();
 
-  private int moduleSynchronizationCounter = 0;
-  private int tempSynchCounter = 0;
-
   /**
    * This function is run when the robot is first started up and should be used for any
    * initialization code.
@@ -109,18 +106,7 @@ public class Robot extends TimedRobot {
   public void disabledInit() {}
 
   @Override
-  public void disabledPeriodic() {
-    if (!SwerveSubsystem.getInstance().isChassisMoving(0.01) && !SwerveSubsystem.getInstance().areModulesRotating(10)) {
-      if (++moduleSynchronizationCounter > 6 && SwerveSubsystem.getInstance().isSwerveNotSynched()) {
-        SwerveSubsystem.getInstance().synchSwerve();
-        System.out.println("Resynced" + ++tempSynchCounter);
-        moduleSynchronizationCounter = 0;
-      }
-    }
-    else {
-      moduleSynchronizationCounter = 0;
-    }
-  }
+  public void disabledPeriodic() {}
 
   /** This autonomous runs the autonomous command selected by your {@link PoseidonContainer} class. */
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,7 +23,6 @@ import frc.robot.robotcontainers.NewRobotContainer;
 import frc.robot.robotcontainers.PoseidonContainer;
 import frc.robot.robotcontainers.RobotContainer;
 import frc.robot.subsystems.ArmSubsystem;
-import frc.robot.subsystems.SwerveSubsystem;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,6 +23,7 @@ import frc.robot.robotcontainers.NewRobotContainer;
 import frc.robot.robotcontainers.PoseidonContainer;
 import frc.robot.robotcontainers.RobotContainer;
 import frc.robot.subsystems.ArmSubsystem;
+import frc.robot.subsystems.SwerveSubsystem;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
@@ -34,6 +35,9 @@ public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
   private RobotContainer m_robotContainer;
   public static CTREConfigs ctreConfigs = new CTREConfigs();
+
+  private int moduleSynchronizationCounter = 0;
+  private int tempSynchCounter = 0;
 
   /**
    * This function is run when the robot is first started up and should be used for any
@@ -105,7 +109,18 @@ public class Robot extends TimedRobot {
   public void disabledInit() {}
 
   @Override
-  public void disabledPeriodic() {}
+  public void disabledPeriodic() {
+    if (!SwerveSubsystem.getInstance().isChassisMoving(0.01) && !SwerveSubsystem.getInstance().areModulesRotating(10)) {
+      if (++moduleSynchronizationCounter > 6 && SwerveSubsystem.getInstance().isSwerveNotSynched()) {
+        SwerveSubsystem.getInstance().synchSwerve();
+        System.out.println("Resynced" + ++tempSynchCounter);
+        moduleSynchronizationCounter = 0;
+      }
+    }
+    else {
+      moduleSynchronizationCounter = 0;
+    }
+  }
 
   /** This autonomous runs the autonomous command selected by your {@link PoseidonContainer} class. */
   @Override

--- a/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/NewRobotContainer.java
@@ -112,8 +112,8 @@ public class NewRobotContainer extends RobotContainer {
     driver.x().whileTrue(new RotateToAngle(driver, Rotation2d.fromDegrees(90)));
     driver.a().whileTrue(new RotateToAngle(driver, Rotation2d.fromDegrees(180)));
     driver.b().whileTrue(new RotateToAngle(driver, Rotation2d.fromDegrees(270)));
-    driver.start().whileTrue(new RotateAngleToVisionSupplier(driver, "photonvision/" + PhotonConfig.apriltagCameraName));    
-
+    // driver.start().whileTrue(new RotateAngleToVisionSupplier(driver, "photonvision/" + PhotonConfig.apriltagCameraName));    
+    driver.start().onTrue(Commands.runOnce(() -> SwerveSubsystem.getInstance().synchSwerve()));
     // Vision scoring commands with no intake, shooter, arm
     // driver.leftTrigger().whileTrue(new SelectByAllianceCommand( // Implement command group that also controls the arm, intake, shooter
     //   PhotonSubsystem.getInstance().getAprilTagCommand(PhotonPositions.AMP_BLUE, driver), 

--- a/src/main/java/frc/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveModule.java
@@ -146,7 +146,7 @@ public class SwerveModule {
 
   private void configAngleMotor() {
     configureSpark("Angle restore factory defaults", () -> angleMotor.restoreFactoryDefaults());
-    CANSparkMaxUtil.setCANSparkMaxBusUsage(angleMotor, Usage.kPositionOnly);
+    CANSparkMaxUtil.setCANSparkMaxBusUsage(angleMotor, Usage.kAll);
     configureSpark("Angle smart current limit", () -> angleMotor.setSmartCurrentLimit(Config.Swerve.angleContinuousCurrentLimit));
     angleMotor.setInverted(Config.Swerve.angleInvert);
     configureSpark("Angle idle mode", () -> angleMotor.setIdleMode(Config.Swerve.angleNeutralMode));

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -355,16 +355,16 @@ public class SwerveSubsystem extends SubsystemBase {
     // If the robot isn't moving synchronize the encoders every 100ms (Inspired by democrat's SDS
     // lib)
     // To ensure that everytime we initialize it works.
-    if (!isChassisMoving(0.01) && !areModulesRotating(2)) {
-      if (++moduleSynchronizationCounter > 6 && isSwerveNotSynched()) {
-        synchSwerve();
-        System.out.println("Resynced" + ++tempSynchCounter);
-        moduleSynchronizationCounter = 0;
-      }
-    }
-    else {
-      moduleSynchronizationCounter = 0;
-    }
+    // if (!isChassisMoving(0.01) && !areModulesRotating(2)) {
+    //   if (++moduleSynchronizationCounter > 6 && isSwerveNotSynched()) {
+    //     synchSwerve();
+    //     System.out.println("Resynced" + ++tempSynchCounter);
+    //     moduleSynchronizationCounter = 0;
+    //   }
+    // }
+    // else {
+    //   moduleSynchronizationCounter = 0;
+    // }
 
     poseBuffer.addPoseToBuffer(getPose());
 

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -355,16 +355,16 @@ public class SwerveSubsystem extends SubsystemBase {
     // If the robot isn't moving synchronize the encoders every 100ms (Inspired by democrat's SDS
     // lib)
     // To ensure that everytime we initialize it works.
-    // if (!isChassisMoving(0.01) && !areModulesRotating(2)) {
-    //   if (++moduleSynchronizationCounter > 6 && isSwerveNotSynched()) {
-    //     synchSwerve();
-    //     System.out.println("Resynced" + ++tempSynchCounter);
-    //     moduleSynchronizationCounter = 0;
-    //   }
-    // }
-    // else {
-    //   moduleSynchronizationCounter = 0;
-    // }
+    if (DriverStation.isDisabled() && !isChassisMoving(0.01) && !areModulesRotating(2)) {
+      if (++moduleSynchronizationCounter > 6 && isSwerveNotSynched()) {
+        synchSwerve();
+        System.out.println("Resynced" + ++tempSynchCounter);
+        moduleSynchronizationCounter = 0;
+      }
+    }
+    else {
+      moduleSynchronizationCounter = 0;
+    }
 
     poseBuffer.addPoseToBuffer(getPose());
 


### PR DESCRIPTION
Disabled the automatic syncing code from running all the time. It is moved into the disabledPeriodic() in Robot.java. That way, the encoder syncing code that has given us really good autos is still the same for auto. I am worried that removing the automatic encoder syncing entirely would break our amazing auto routines.

Attached manually syncing onto the start button of the driver joystick.